### PR TITLE
Feat detect page boundaries

### DIFF
--- a/docs/examples/AsyncPagination.js
+++ b/docs/examples/AsyncPagination.js
@@ -33,6 +33,7 @@ export default class AsyncPagination extends Component<*, State> {
         cacheOptions
         defaultOptions
         loadOptionsPagination={promiseOptions}
+        menuPlacement="autoFlip"
       />
     );
   }

--- a/src/Select.js
+++ b/src/Select.js
@@ -493,7 +493,7 @@ export default class Select extends Component<Props, State> {
     const { isMulti, shouldFocusOnOpen } = this.props;
     const newState = {};
     let openAtIndex;
-    if(shouldFocusOnOpen) {
+    if (shouldFocusOnOpen) {
       openAtIndex = focusOption === 'first' ? 0 : menuOptions.focusable.length - 1;
 
       if (!isMulti) {

--- a/src/Select.js
+++ b/src/Select.js
@@ -244,7 +244,9 @@ export type Props = {
   /* The value of the select; reflected by the selected option */
   value: ValueType,
   /* A CSP Nonce which will be used in injected style sheets */
-  nonce?: string
+  nonce?: string,
+  /* Whether or not a menu item should be focused upon opening the menu */
+  shouldFocusOnOpen: boolean
 };
 
 export const defaultProps = {
@@ -285,6 +287,7 @@ export const defaultProps = {
   styles: {},
   tabIndex: '0',
   tabSelectsValue: true,
+  shouldFocusOnOpen: true
 };
 
 type MenuOptions = {
@@ -487,25 +490,28 @@ export default class Select extends Component<Props, State> {
 
   openMenu(focusOption: 'first' | 'last') {
     const { menuOptions, selectValue } = this.state;
-    const { isMulti } = this.props;
-    let openAtIndex =
-      focusOption === 'first' ? 0 : menuOptions.focusable.length - 1;
+    const { isMulti, shouldFocusOnOpen } = this.props;
+    const newState = {};
+    let openAtIndex;
+    if(shouldFocusOnOpen) {
+      openAtIndex = focusOption === 'first' ? 0 : menuOptions.focusable.length - 1;
 
-    if (!isMulti) {
-      const selectedIndex = menuOptions.focusable.indexOf(selectValue[0]);
-      if (selectedIndex > -1) {
-        openAtIndex = selectedIndex;
+      if (!isMulti) {
+        const selectedIndex = menuOptions.focusable.indexOf(selectValue[0]);
+        if (selectedIndex > -1) {
+          openAtIndex = selectedIndex;
+        }
       }
+      newState.focusedOption = menuOptions.focusable[openAtIndex];
     }
 
     this.scrollToFocusedOptionOnUpdate = true;
     this.inputIsHiddenAfterUpdate = false;
 
     this.onMenuOpen();
-    this.setState({
-      focusedValue: null,
-      focusedOption: menuOptions.focusable[openAtIndex],
-    });
+
+    newState.focusedValue =  null;
+    this.setState(newState);
 
     this.announceAriaLiveContext({ event: 'menu' });
   }
@@ -1001,7 +1007,7 @@ export default class Select extends Component<Props, State> {
     if (!touch) {
       return;
     }
-    
+
     this.initialTouchX = touch.clientX;
     this.initialTouchY = touch.clientY;
     this.userIsDragging = false;

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -39,7 +39,7 @@ type PlacementArgs = {
   maxHeight: number,
   menuEl: ElementRef<*>,
   minHeight: number,
-  placement: 'bottom' | 'top' | 'auto',
+  placement: 'bottom' | 'top' | 'auto' | 'autoFlip',
   shouldScroll: boolean,
   isFixedPosition: boolean,
   theme: Theme,
@@ -149,6 +149,14 @@ export function getMenuPlacement({
         return { placement: 'bottom', maxHeight };
       }
       break;
+    case 'autoFlip':
+      // menu will fit
+      if (viewSpaceBelow >= menuHeight) {
+        return { placement: 'bottom', maxHeight };
+      } else {
+      // menu won't fit so needs to be flipped
+        return { placement: 'top', maxHeight: maxHeight };
+      }
     case 'top':
       // 1: the menu will fit, do nothing
       if (viewSpaceAbove >= menuHeight) {


### PR DESCRIPTION
Menu will now flip if the menuPlacement prop is set to autoFlip. This is to stop the menu opening off the page and the user having to scroll to it. Instead it will simply open upwards.